### PR TITLE
Add link to OpenStack Infra LogStash filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ OpenStack Logging Tools
 logstash
 
 Example dashboards for Kibana and logging configurations for logstash.
+
+Other sources of logging tools
+------------------------------
+
+* The [OpenStack Infra team](http://docs.openstack.org/infra/system-config/)
+runs [logstash.openstack.org](http://logstash.openstack.org/) for debugging
+test jobs and has filters available
+[here](http://git.openstack.org/cgit/openstack-infra/system-config/tree/modules/openstack_project/templates/logstash/indexer.conf.erb).


### PR DESCRIPTION
Joe Gordon noted on the openstack-operators ML [1] that the OpenStack
Infra team runs an ELK stack and has it's filters available for interested
parties to peruse.  This patch adds a link to Infra's filters in the
README file similar to the way they're laid out in the README for the
tools-generic repo [2].

[1]
http://lists.openstack.org/pipermail/openstack-operators/2015-May/007133.html
[2]
https://raw.githubusercontent.com/osops/tools-generic/master/README.md